### PR TITLE
Release `lawful-classes-{hedgehog,quickcheck}` 0.1.1.0

### DIFF
--- a/lawful-classes-demo/lawful-classes-demo.cabal
+++ b/lawful-classes-demo/lawful-classes-demo.cabal
@@ -69,8 +69,8 @@ test-suite lawful-classes-demo-test
     , base                       ^>=4.14.3.0 || ^>=4.15.1.0 || ^>=4.16.4.0 || ^>=4.17.0.0
     , hedgehog                   ^>=1.2
     , lawful-classes-demo
-    , lawful-classes-hedgehog    ^>=0.1.0.0
-    , lawful-classes-quickcheck  ^>=0.1.0.0
+    , lawful-classes-hedgehog    ^>=0.1.1.0
+    , lawful-classes-quickcheck  ^>=0.1.1.0
     , QuickCheck                 ^>=2.14.2
     , tasty                      ^>=1.4.3
     , tasty-expected-failure     ^>=0.12.3

--- a/lawful-classes-hedgehog/CHANGELOG.md
+++ b/lawful-classes-hedgehog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for lawful-classes-hedgehog
 
-## 0.1.1.0 -- YYYY-mm-dd
+## 0.1.1.0 -- 2023-02-01
 
 * Add `Test.Lawful.Hedgehog.testLawsWith`.
 

--- a/lawful-classes-quickcheck/CHANGELOG.md
+++ b/lawful-classes-quickcheck/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for lawful-classes-quickcheck
 
-## 0.1.1.0 -- YYYY-mm-dd
+## 0.1.1.0 -- 2023-02-01
 
 * Add `Test.Lawful.QuickCheck.testLawsWith`.
 


### PR DESCRIPTION
Also includes a bugfix for an incorrect version bounds definition in `lawful-classes-demo`, which wasn't caught due to the use of in-tree versions of the respective libraries.