### PR TITLE
Support GHC 9.2.4 / base 4.16.3.0

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -38,6 +38,11 @@ jobs:
             compilerVersion: 9.2.5
             setup-method: ghcup
             allow-failure: false
+          - compiler: ghc-9.2.4
+            compilerKind: ghc
+            compilerVersion: 9.2.4
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.0.2
             compilerKind: ghc
             compilerVersion: 9.0.2

--- a/lawful-classes-demo/lawful-classes-demo.cabal
+++ b/lawful-classes-demo/lawful-classes-demo.cabal
@@ -23,7 +23,7 @@ extra-doc-files: CHANGELOG.md
 
 -- extra-source-files:
 
-tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.5 || ==9.4.4
+tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.2.5 || ==9.4.4
 
 source-repository head
   type:     git
@@ -46,7 +46,7 @@ library
     MultiParamTypeClasses
 
   build-depends:
-    , base                  ^>=4.14.3.0 || ^>=4.15.1.0 || ^>=4.16.4.0 || ^>=4.17.0.0
+    , base                  ^>=4.14.3.0 || ^>=4.15.1.0 || ^>=4.16.3.0 || ^>=4.17.0.0
     , lawful-classes-types  ^>=0.1.0.0
     , mtl                   ^>=2.2.2
     , transformers          ^>=0.5.6.2
@@ -66,7 +66,7 @@ test-suite lawful-classes-demo-test
   hs-source-dirs:   test
   main-is:          Main.hs
   build-depends:
-    , base                       ^>=4.14.3.0 || ^>=4.15.1.0 || ^>=4.16.4.0 || ^>=4.17.0.0
+    , base                       ^>=4.14.3.0 || ^>=4.15.1.0 || ^>=4.16.3.0 || ^>=4.17.0.0
     , hedgehog                   ^>=1.2
     , lawful-classes-demo
     , lawful-classes-hedgehog    ^>=0.1.1.0

--- a/lawful-classes-hedgehog/CHANGELOG.md
+++ b/lawful-classes-hedgehog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for lawful-classes-hedgehog
 
+## 0.1.1.1 -- YYYY-mm-dd
+
+* Support GHC 9.2.4 / base 4.16.3.0.
+
 ## 0.1.1.0 -- 2023-02-01
 
 * Add `Test.Lawful.Hedgehog.testLawsWith`.

--- a/lawful-classes-hedgehog/lawful-classes-hedgehog.cabal
+++ b/lawful-classes-hedgehog/lawful-classes-hedgehog.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            lawful-classes-hedgehog
-version:         0.1.1.0
+version:         0.1.1.1
 synopsis:        Hedgehog support for lawful-classes
 description:
   Support code to check @lawful-classes@ laws using Hedgehog and,
@@ -18,7 +18,7 @@ extra-doc-files: CHANGELOG.md
 
 -- extra-source-files:
 
-tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.5 || ==9.4.4
+tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.2.5 || ==9.4.4
 
 source-repository head
   type:     git
@@ -36,7 +36,7 @@ library
   -- other-modules:
   other-extensions: RankNTypes
   build-depends:
-    , base                  ^>=4.14.3.0 || ^>=4.15.1.0 || ^>=4.16.4.0 || ^>=4.17.0.0
+    , base                  ^>=4.14.3.0 || ^>=4.15.1.0 || ^>=4.16.3.0 || ^>=4.17.0.0
     , hedgehog              ^>=1.2
     , lawful-classes-types  ^>=0.1.0.0
     , tasty                 ^>=1.4.3

--- a/lawful-classes-quickcheck/CHANGELOG.md
+++ b/lawful-classes-quickcheck/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for lawful-classes-quickcheck
 
+## 0.1.1.1 -- YYYY-mm-dd
+
+* Support GHC 9.2.4 / base 4.16.3.0.
+
 ## 0.1.1.0 -- 2023-02-01
 
 * Add `Test.Lawful.QuickCheck.testLawsWith`.

--- a/lawful-classes-quickcheck/lawful-classes-quickcheck.cabal
+++ b/lawful-classes-quickcheck/lawful-classes-quickcheck.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            lawful-classes-quickcheck
-version:         0.1.1.0
+version:         0.1.1.1
 synopsis:        QuickCheck support for lawful-classes
 description:
   Support code to check @lawful-classes@ laws using QuickCheck and,
@@ -18,7 +18,7 @@ extra-doc-files: CHANGELOG.md
 
 -- extra-source-files:
 
-tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.5 || ==9.4.4
+tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.2.5 || ==9.4.4
 
 source-repository head
   type:     git
@@ -36,7 +36,7 @@ library
   -- other-modules:
   other-extensions: RankNTypes
   build-depends:
-    , base                  ^>=4.14.3.0 || ^>=4.15.1.0 || ^>=4.16.4.0 || ^>=4.17.0.0
+    , base                  ^>=4.14.3.0 || ^>=4.15.1.0 || ^>=4.16.3.0 || ^>=4.17.0.0
     , lawful-classes-types  ^>=0.1.0.0
     , QuickCheck            ^>=2.14.2
     , tasty                 ^>=1.4.3

--- a/lawful-classes-types/CHANGELOG.md
+++ b/lawful-classes-types/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for lawful-classes-types
 
+## 0.1.0.1 -- YYYY-mm-dd
+
+* Support GHC 9.2.4 / base 4.16.3.0.
+
 ## 0.1.0.0 -- 2023-02-01
 
 * First version. Released on an unsuspecting world.

--- a/lawful-classes-types/lawful-classes-types.cabal
+++ b/lawful-classes-types/lawful-classes-types.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            lawful-classes-types
-version:         0.1.0.0
+version:         0.1.0.1
 synopsis:        Types for lawful-classes
 description:
   Type definitions (aliases) and basic utility functions used in the
@@ -18,7 +18,7 @@ extra-doc-files: CHANGELOG.md
 
 -- extra-source-files:
 
-tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.5 || ==9.4.4
+tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.2.5 || ==9.4.4
 
 source-repository head
   type:     git
@@ -36,7 +36,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:
-    base ^>=4.14.3.0 || ^>=4.15.1.0 || ^>=4.16.4.0 || ^>=4.17.0.0
+    base ^>=4.14.3.0 || ^>=4.15.1.0 || ^>=4.16.3.0 || ^>=4.17.0.0
 
   hs-source-dirs:   src
   default-language: Haskell2010


### PR DESCRIPTION
The documentation build environment on Hackage is based on GHC 9.2.4, which was not tested/supported before, hence builds failed.

This lowers the required version of `base` (in the ^>=4.16 range) to 4.16.3.0, and bumps the patch versions of impacted packages accordingly.

Also, test using GHC 9.2.4 in CI.